### PR TITLE
Suppress jsx-a11y/no-autofocus on the landing page search input

### DIFF
--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -76,6 +76,9 @@ export default function Index() {
             name="username"
             type="search"
             placeholder="rwaldron"
+            // The landing page is a single-purpose search form; focusing the
+            // input on load matches the user's intent and avoids an extra tab.
+            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
           />
         </div>


### PR DESCRIPTION
The landing page is a single-purpose search form — the user's intent on arrival is to type a username. Auto-focusing the input matches that intent and saves a Tab, so we accept the accessibility tradeoff here with an inline eslint-disable and a comment explaining the reasoning.