### PR TITLE
Import z as a named import from zod

### DIFF
--- a/app/routes/_index/parseUsername.ts
+++ b/app/routes/_index/parseUsername.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "zod";
 import zx from "zodix";
 
 export const parseUsername = async (formData: FormData) => {

--- a/app/routes/_index/route.spec.tsx
+++ b/app/routes/_index/route.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import z from "zod";
+import { z } from "zod";
 import { action } from "./route";
 import * as parseUsernameModule from "./parseUsername";
 import { ActionFunctionArgs } from "@remix-run/node";


### PR DESCRIPTION
## Summary
Zod exports `z` as a named export, not a default. Importing it as `import z from "zod"` tripped eslint's `import/no-named-as-default` rule because the identifier happens to collide with a real named export. Switching to `import { z } from "zod"` clears the two remaining lint warnings and matches zod's documented usage.

Touches `app/routes/_index/parseUsername.ts` and `app/routes/_index/route.spec.tsx`. Runtime behavior unchanged — `zod` works the same either way, this is purely a lint-hygiene fix.

## Test plan
- [x] `npm run lint` — 2 warnings → 0
- [x] `npm run typecheck` — passes
- [x] `npm test` — 31/31 pass