### PR TITLE
Add CI workflow running lint, typecheck, test, and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test -- --run
+
+      - name: Build
+        run: npm run build
+
+      # Fails on any NEW critical finding. High/moderate transitive issues
+      # (esbuild, tar, minimatch, tmp, yaml) need major upgrades and are
+      # tracked for follow-up PRs; don't break the build on them yet.
+      - name: Audit (critical only)
+        run: npm audit --audit-level=critical


### PR DESCRIPTION
## Summary
Adds `.github/workflows/ci.yml`. Runs on push to `main` and on every pull request.

**Steps** (all in one job so `npm ci` / the npm cache is only paid once):
1. `npm ci`
2. `npm run lint`
3. `npm run typecheck`
4. `npm test -- --run`
5. `npm run build`
6. `npm audit --audit-level=critical`

**Audit threshold**: pinned to `critical` so any new critical regression (e.g. another happy-dom-class CVE) breaks the build. The known high/moderate transitives (esbuild, tar, minimatch, tmp, yaml) need major upgrades to vitest@4 / vite@8 / cucumber@12 / @typescript-eslint@8 — those are follow-up PRs, and we don't want CI blocking on them in the meantime.

**Out of scope**
- e2e (playwright / cucumber): browsers + tokens aren't wired up yet. Happy to add in a follow-up — pick `GITHUB_TOKEN` secrets strategy first.
- Multi-Node matrix: single Node 20 for now; can expand later if we add a compat story.

## Test plan
- [x] `npm ci`, `lint`, `typecheck`, `test --run`, `build`, `audit --audit-level=critical` all pass locally.
- [ ] First CI run on this PR should go green — that's the real verification.