### PR TITLE
Upgrade TypeScript to 5.9

### DIFF
--- a/app/routes/$username.[preview.png]/route.tsx
+++ b/app/routes/$username.[preview.png]/route.tsx
@@ -10,7 +10,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   }
   const imageBuffer = createPreviewImage(username, topGists[0]);
 
-  return new Response(imageBuffer, {
+  return new Response(new Uint8Array(imageBuffer), {
     status: 200,
     headers: {
       "Cache-Control": "public, max-age=3600, s-maxage=3600", // cache for 3 hours

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "playwright": "^1.44.1",
         "prettier": "^3.2.5",
         "tsx": "^4.11.0",
-        "typescript": "~5.3.0",
+        "typescript": "~5.9.0",
         "typescript-eslint": "^8.24.0",
         "vcr-test": "^1.0.9",
         "vite": "^5.1.0",
@@ -14039,9 +14039,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "playwright": "^1.44.1",
     "prettier": "^3.2.5",
     "tsx": "^4.11.0",
-    "typescript": "~5.3.0",
+    "typescript": "~5.9.0",
     "vcr-test": "^1.0.9",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.2.1",


### PR DESCRIPTION
Bump typescript from ~5.3.0 to ~5.9.0.

TS 5.7 made Buffer generic over ArrayBufferLike, which no longer satisfies DOM's BodyInit. Wrap the PNG Buffer in a plain Uint8Array before handing it to the Response constructor.