### PR TITLE
Upgrade Zod to v4 and update validation code

### DIFF
--- a/app/routes/_index/parseUsername.ts
+++ b/app/routes/_index/parseUsername.ts
@@ -6,7 +6,7 @@ const schema = z.object({
     .trim()
     .toLowerCase()
     .max(39)
-    .nonempty("username must contain a least 1 character")
+    .min(1, "username must contain a least 1 character")
     .regex(/^[a-zA-Z0-9]+[a-zA-Z0-9-]*$/, "username must be alphanumeric"),
 });
 

--- a/app/routes/_index/route.spec.tsx
+++ b/app/routes/_index/route.spec.tsx
@@ -28,7 +28,7 @@ describe("index action", () => {
   it("should return an error message when username is invalid", async () => {
     vi.spyOn(parseUsernameModule, "parseUsername").mockResolvedValue({
       success: false,
-      error: new z.ZodError([]),
+      error: new z.ZodError([]) as z.ZodError<{ username: string }>,
     });
     const response = await action({
       request: request(),

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import styles from "./route.module.css";
 import {
   Form,
@@ -42,9 +43,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   if (result.success) {
     return redirect(`/${result.data.username}`);
   }
-  const fieldErrors: { username?: string[] } = result.error.flatten()
-    .fieldErrors as { username?: string[] };
-  return data(fieldErrors, { status: 400 });
+  return data(z.flattenError(result.error).fieldErrors, { status: 400 });
 };
 
 const POPULAR: { name: string; suit: "♠" | "♥" | "♦" | "♣" }[] = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router": "^7.14.1",
-        "zod": "^3.23.8"
+        "zod": "^4.4.2"
       },
       "devDependencies": {
         "@cucumber/cucumber": "^12.8.1",
@@ -11235,9 +11235,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
+      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router": "^7.14.1",
-    "zod": "^3.23.8"
+    "zod": "^4.4.2"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.8.1",


### PR DESCRIPTION
## Summary
This PR upgrades Zod from v3.23.8 to v4.4.2 and updates the codebase to be compatible with the new API changes.

## Key Changes
- **Upgraded Zod dependency** from v3.23.8 to v4.4.2
- **Replaced deprecated `nonempty()` method** with `min(1, ...)` in the username validation schema, as `nonempty()` was removed in Zod v4
- **Updated error flattening** to use the new `z.flattenError()` utility function instead of manually casting `result.error.flatten().fieldErrors`
- **Updated test type annotation** to properly type the ZodError with the schema shape `z.ZodError<{ username: string }>`

## Implementation Details
The changes maintain the same validation behavior while adapting to Zod v4's API:
- The `min(1, ...)` validator provides the same functionality as the deprecated `nonempty()` with an explicit error message
- The `z.flattenError()` utility provides a cleaner, type-safe way to flatten validation errors
- All validation logic and error handling behavior remains unchanged

https://claude.ai/code/session_01DDrzmFasMMG4pJsM4ppjsq