### PR TITLE
Remove legacy-peer-deps npm configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -10397,7 +10397,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## Summary
Removed the `legacy-peer-deps=true` configuration from `.npmrc`, allowing npm to enforce strict peer dependency resolution.

## Changes
- Deleted `.npmrc` file that was previously configured to bypass peer dependency warnings

## Details
This change removes the workaround that was suppressing peer dependency conflicts. The project will now use npm's default peer dependency resolution behavior, which may require addressing any unresolved peer dependencies in the project or its dependencies.

https://claude.ai/code/session_01DDrzmFasMMG4pJsM4ppjsq