### PR TITLE
Replace deprecated Buffer constructor with Buffer.from()

### DIFF
--- a/app/routes/$username.[preview.png]/route.spec.tsx
+++ b/app/routes/$username.[preview.png]/route.spec.tsx
@@ -22,7 +22,7 @@ describe("loader", () => {
       }),
     ]);
     vi.spyOn(previewService, "createPreviewImage").mockReturnValue(
-      new Buffer(""),
+      Buffer.from(""),
     );
     const response = await loader(
       stub<LoaderFunctionArgs>({


### PR DESCRIPTION
## Summary
Updated the test file to use the modern `Buffer.from()` API instead of the deprecated `new Buffer()` constructor.

## Key Changes
- Replaced `new Buffer("")` with `Buffer.from("")` in the preview image service mock

## Implementation Details
This change addresses a deprecation warning in Node.js. The `new Buffer()` constructor has been deprecated in favor of `Buffer.from()`, `Buffer.alloc()`, and `Buffer.allocUnsafe()` for improved safety and clarity. Using `Buffer.from()` is the appropriate choice here as it creates a buffer from the provided string data.

https://claude.ai/code/session_01DDrzmFasMMG4pJsM4ppjsq