### PR TITLE
Patch remaining audit moderates via pnpm overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      # Fails on any NEW critical finding. High/moderate transitive issues
-      # (esbuild, tar, minimatch, tmp, yaml) need major upgrades and are
-      # tracked for follow-up PRs; don't break the build on them yet.
+      # Fails on any NEW critical finding. The audit currently reports
+      # zero vulnerabilities; raise the floor to "moderate" if/when we
+      # want to gate on transitive issues too.
       - name: Audit (critical only)
         run: pnpm audit --audit-level=critical

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
   },
   "packageManager": "pnpm@10.33.2",
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "unrs-resolver"]
+    "onlyBuiltDependencies": ["esbuild", "unrs-resolver"],
+    "overrides": {
+      "@vercel/static-config>ajv": "^8.18.0",
+      "yaml@<2.8.3": "^2.8.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@vercel/static-config>ajv': ^8.18.0
+  yaml@<2.8.3: ^2.8.3
+
 importers:
 
   .:
@@ -1344,8 +1348,8 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
-  ajv@8.6.3:
-    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@4.1.1:
     resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
@@ -1933,6 +1937,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3306,7 +3313,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3347,7 +3354,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3467,11 +3474,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yaml@2.8.0:
-    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yaml@2.8.4:
     resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
@@ -4573,7 +4575,7 @@ snapshots:
 
   '@vercel/static-config@3.3.0':
     dependencies:
-      ajv: 8.6.3
+      ajv: 8.20.0
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
@@ -4641,12 +4643,12 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.6.3:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-      uri-js: 4.4.1
 
   ansi-regex@4.1.1: {}
 
@@ -5412,6 +5414,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.0: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6818,7 +6822,7 @@ snapshots:
   vcr-test@1.4.0:
     dependencies:
       '@mswjs/interceptors': 0.23.0
-      yaml: 2.8.0
+      yaml: 2.8.4
 
   vite-node@3.2.4(@types/node@25.6.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
@@ -6957,8 +6961,6 @@ snapshots:
   xmlbuilder@15.1.1: {}
 
   yallist@3.1.1: {}
-
-  yaml@2.8.0: {}
 
   yaml@2.8.4: {}
 


### PR DESCRIPTION
pnpm audit reported two transitive moderates:
- ajv <8.18.0 via @vercel/react-router>@vercel/static-config>ajv (ReDoS, GHSA-2g4f-4pwh-qvx6)
- yaml <2.8.3 via vcr-test>yaml (stack overflow on deeply nested collections, GHSA-48c2-rrv3-qjmp)

Both have patches inside the same major. Pin them with pnpm.overrides.

Scope the ajv override to "@vercel/static-config>ajv" rather than ajv globally — eslint/eslintrc still pulls ajv 6 (which isn't vulnerable and isn't compatible with ajv 8's API; a global override broke lint with "Cannot set properties of undefined (setting 'defaultMeta')").

Update the CI step's stale comment listing esbuild/tar/minimatch/tmp/ yaml — those have all dropped out of the audit since the dep bumps that followed.

Audit now reports zero vulnerabilities. Typecheck, lint, 31 tests, and build all pass.